### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p  /go/src/github.com/google/ && \
 
 RUN ls -la /go/bin
 
-FROM fish/nginx-exporter:v0.1.0 as status
+FROM fish/nginx-exporter:v0.1.1 as status
 
 FROM alpine:3.8
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ spec:
           mountPath: /var/log/nginx/mtail
 
       - name: exporter
-        image: quay.io/rebuy/nginx-exporter:v1.0.0
+        image: quay.io/rebuy/nginx-exporter:v1.1.0
 
         ports:
         - containerPort: 9397


### PR DESCRIPTION
Hello, team!

This PR bumps fish/nginx-exporter to newer version, and fixes README (as it for now have newer log format and old application version).